### PR TITLE
Update CCScroller.cpp

### DIFF
--- a/cocos2dx-common/src/CCScroller.cpp
+++ b/cocos2dx-common/src/CCScroller.cpp
@@ -80,8 +80,8 @@ bool CCScroller::computeScrollOffset() {
 				float x = (float) timePassed * m_durationReciprocal;
 				x = viscousFluid(x);
 
-				m_currX = m_startX + round(x * m_deltaX);
-				m_currY = m_startY + round(x * m_deltaY);
+				m_currX = m_startX + x * m_deltaX;
+				m_currY = m_startY + x * m_deltaY;
 				break;
 			}
 			case FLING_MODE:


### PR DESCRIPTION
Compared to android, the cocos2dx coordinate system has float value. So I don't think we should round the return value.
# And the current code would cause a problem like this

when I'm doing like this

m_scroller->startScroll(0.1818,0,100,0,1000);

then compute the offset.

At beginning the return value appears normal, but when approaching the end scroll, the getCurrX method would return 100.1818, which is larger than the finalX.

After I remove the round method, it seems to be normal now.
